### PR TITLE
Properly export `getCoordsNAVIEW` and `NAView` to resolve runtime errors

### DIFF
--- a/src/layouts/naview/getnaview.js
+++ b/src/layouts/naview/getnaview.js
@@ -1,6 +1,6 @@
 var NAView = require("./naview");
 
-getCoordsNAVIEW = module.exports = function(nodes, links){
+function getCoordsNAVIEW(nodes, links){
 	//Calculates coordinates according to the NAView layout
 	var pairTable = [];
 
@@ -42,3 +42,5 @@ function getPartner(srcIndex, links){
 	}
 	return partner;
 }
+
+module.exports = getCoordsNAVIEW;

--- a/src/layouts/naview/naview.js
+++ b/src/layouts/naview/naview.js
@@ -4,7 +4,7 @@ var Region = require("./region");
 var Connection = require("./connection");
 var Radloop = require("./radloop");
 
-var NAView = module.exports = function(){
+function NAView (){
     this.ANUM = 9999.0;
 	this.MAXITER = 500;
 
@@ -223,7 +223,7 @@ NAView.prototype.find_central_loop = function find_central_loop(){
     var maxdepth = null;
     var i = null;
 
-    determine_depths();
+    this.determine_depths();
     maxconn = 0;
     maxdepth = -1;
     for (i = 0; i < this.loop_count; i++) {
@@ -240,7 +240,7 @@ NAView.prototype.find_central_loop = function find_central_loop(){
     }
 }
 
-function determine_depths() {
+NAView.prototype.determine_depths = function determine_depths() {
     var lp = new Loop();
     var i = null;
     var j = null;
@@ -1096,3 +1096,5 @@ NAView.prototype.connected_connection = function connected_connection(cp, cpnext
         return false;
     }
 }
+
+module.exports = NAView;


### PR DESCRIPTION
This PR addresses issues encountered when running drawrnajs, specifically errors such as `getCoordsNAVIEW is undefined`. The root causes were related to incorrect export patterns and method scoping in the NAView layout modules. These changes ensure that both `getCoordsNAVIEW` and `NAView` are correctly defined, scoped, and exported. This eliminates reference errors and allows drawrnajs to initialize and run without crashing.

### Changes made
- **`src/layouts/naview/getnaview.js`**  
  - Refactored `getCoordsNAVIEW` to be properly defined as a function before exporting.  
  - Moved the `module.exports = getCoordsNAVIEW` statement to the end of the file after the function declaration.
  
- **`src/layouts/naview/naview.js`**  
  - Refactored `NAView` from being directly assigned to `module.exports` to a standard function declaration.  
  - Fixed scoping issues where `determine_depths` was previously defined as a standalone function; it is now correctly set as a method on `NAView.prototype` and called with `this.determine_depths()`.
  - Added `module.exports = NAView` at the end of the file to properly export the constructor function.
